### PR TITLE
add optional `repos` list as an alternative to the all-repos default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ GO111MODULE=off go get github.com/displague/github-labeller
 **First**, make sure `labels.json` exists and has all of the labels you want to
 add to your repositories.
 
+If `repos` is not present in the file, the labels provided will be added to all
+repositories in the organization.
+
+```json
+{
+  "repos": ["foo", "bar"],
+  "labels": [{"name":"labelA", "color": "b0b0b0", "description": "Label A"}]
+}
+```
+
+
+Then run `github-labeller` with a `GITHUB_TOKEN` set in the environment:
+
 ```console
 GITHUB_TOKEN=... github-labeller ORG
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/displague/github-labeller
 go 1.14
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github/v32 v32.1.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -20,3 +22,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/labels.json
+++ b/labels.json
@@ -1,47 +1,49 @@
-[
-  {
-    "name": "P1",
-    "color": "fc49e7",
-    "description": "Highest priority"
-  },
-  {
-    "name": "P2",
-    "description": "Medium priority",
-    "color": "ffa836"
-  },
-  {
-    "name": "P3",
-    "description": "Low priority",
-    "color": "b6d157"
-  },
-  {
-    "name": "area/ci-cd-release",
-    "color": "30f43e",
-    "description": "Related to the integration, deployment, or release processes"
-  },
-  {
-    "name": "size/S",
-    "color": "2c4eaa",
-    "description": "estimate of the amount of work to address the issue"
-  },
-  {
-    "name": "size/M",
-    "color": "2c4eaa",
-    "description": "estimate of the amount of work to address the issue"
-  },
-  {
-    "name": "size/L",
-    "color": "2c4eaa",
-    "description": "estimate of the amount of work to address the issue"
-  },
-  {
-    "name": "size/XS",
-    "color": "2c4eaa",
-    "description": "estimate of the amount of work to address the issue"
-  },
-  {
-    "name": "size/XL",
-    "color": "2c4eaa",
-    "description": "estimate of the amount of work to address the issue"
-  }
-]
+{
+  "labels": [
+    {
+      "name": "P1",
+      "color": "fc49e7",
+      "description": "Highest priority"
+    },
+    {
+      "name": "P2",
+      "description": "Medium priority",
+      "color": "ffa836"
+    },
+    {
+      "name": "P3",
+      "description": "Low priority",
+      "color": "b6d157"
+    },
+    {
+      "name": "area/ci-cd-release",
+      "color": "30f43e",
+      "description": "Related to the integration, deployment, or release processes"
+    },
+    {
+      "name": "size/S",
+      "color": "2c4eaa",
+      "description": "estimate of the amount of work to address the issue"
+    },
+    {
+      "name": "size/M",
+      "color": "2c4eaa",
+      "description": "estimate of the amount of work to address the issue"
+    },
+    {
+      "name": "size/L",
+      "color": "2c4eaa",
+      "description": "estimate of the amount of work to address the issue"
+    },
+    {
+      "name": "size/XS",
+      "color": "2c4eaa",
+      "description": "estimate of the amount of work to address the issue"
+    },
+    {
+      "name": "size/XL",
+      "color": "2c4eaa",
+      "description": "estimate of the amount of work to address the issue"
+    }
+  ]
+}


### PR DESCRIPTION
The labels.json format changes in this PR.

A subset of org repos can now be labeled.